### PR TITLE
feat(router): 라우트 분리(AppRoutes) 및 레이아웃 정리, /taro 라우트 복구

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,8 @@
         "@fortawesome/react-fontawesome": "^0.2.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-<<<<<<< HEAD
-        "react-router-dom": "^7.8.0"
-=======
+        "react-router-dom": "^7.8.0",
         "styled-components": "^6.1.19"
->>>>>>> 4e4f39e (feature:home 홈페이지)
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -2326,7 +2323,12 @@
         "react": "^19.1.1"
       }
     },
-<<<<<<< HEAD
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-router": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
@@ -2364,13 +2366,6 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
-=======
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
->>>>>>> 4e4f39e (feature:home 홈페이지)
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2428,17 +2423,16 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
-<<<<<<< HEAD
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-=======
+      "license": "MIT"
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
->>>>>>> 4e4f39e (feature:home 홈페이지)
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,8 @@
     "@fortawesome/react-fontawesome": "^0.2.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-<<<<<<< HEAD
-    "react-router-dom": "^7.8.0"
-=======
+    "react-router-dom": "^7.8.0",
     "styled-components": "^6.1.19"
->>>>>>> 4e4f39e (feature:home 홈페이지)
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,11 @@
-import { useState } from 'react'
-import './App.css'
-import Home from './pages/Home'
+import { BrowserRouter } from 'react-router-dom'
+import AppRoutes from './routes/AppRoutes.jsx'
 
 function App() {
-
   return (
-    <>
-      <Home/>
-    </>
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
   )
 }
 

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,16 +1,9 @@
-import { Outlet, Link } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 
 function Layout() {
   return (
     <div className="app-container">
-      <header style={{ padding: '12px 0' }}>
-        <nav style={{ display: 'flex', gap: 12 }}>
-          <Link to="/">Home</Link>
-        </nav>
-      </header>
-      <main>
-        <Outlet />
-      </main>
+      <Outlet />
     </div>
   )
 }

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -2,9 +2,7 @@ import { Outlet } from 'react-router-dom'
 
 function Layout() {
   return (
-    <div className="app-container">
       <Outlet />
-    </div>
   )
 }
 

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,0 +1,21 @@
+import { Routes, Route } from 'react-router-dom'
+import Layout from '../layouts/Layout.jsx'
+import Home from '../pages/Home.jsx'
+import Taro from '../pages/Taro.jsx'
+import NotFound from '../pages/NotFound.jsx'
+
+function AppRoutes() {
+    return (
+        <Routes>
+            <Route element={<Layout />}>
+                <Route path="/" element={<Home />} />
+                <Route path="/taro" element={<Taro />} />
+                <Route path="*" element={<NotFound />} />
+            </Route>
+        </Routes>
+    )
+}
+
+export default AppRoutes
+
+


### PR DESCRIPTION
## Related issue 🛠
- 관련 이슈 없음
- origin dev -> upstream dev

## Work Description 📝
충돌 해결 과정에서 
- src/routes/AppRoutes.jsx 신설: 라우트 정의를 한 곳에서 관리
- src/App.jsx 간소화: BrowserRouter + <AppRoutes />만 렌더
- src/layouts/Layout.jsx 정리: 불필요 요소 제거, .app-container 적용
- /taro 라우트 복구 (직접 URL 접근 가능)
- 전역 폭/레이아웃은 layout.css의 .app-container(360px) 기준 유지

## Screenshot 📸
<img width="419" height="258" alt="스크린샷 2025-08-11 오후 9 05 26" src="https://github.com/user-attachments/assets/1fbc6e3b-373c-4a43-aa60-5cd333606cfb" />

<img width="516" height="401" alt="스크린샷 2025-08-11 오후 9 05 53" src="https://github.com/user-attachments/assets/199864d0-2484-4bec-b8c2-fd2a827c41e7" />


## To Reviewers 📢
- 실행: npm i → npm run dev → /와 /taro 진입 확인
- 레이아웃 겹침 이슈 제거됨. 모든 페이지는 Layout 하위에서 동일 폭/패딩으로 렌더
- #11(타로 인트로 UI)은 별도 브랜치에서 진행 예정
