### PR TITLE
Feat: taro page api 연결

### DIFF
--- a/src/components/common/PrimaryButton.jsx
+++ b/src/components/common/PrimaryButton.jsx
@@ -14,19 +14,19 @@ const Button = styled.button`
   font-size: 18px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.35);
   cursor: pointer;
-  z-index: ${props => props.zIndex || 1000}; 
-  position: ${props => (props.fixedBottom ? 'fixed' : 'relative')};
-  bottom: ${props => (props.fixedBottom ? 'calc(24px + env(safe-area-inset-bottom))' : 'auto')};
+  z-index: ${props => props.$zIndex || 1000}; 
+  position: ${props => (props.$fixedBottom ? 'fixed' : 'relative')};
+  bottom: ${props => (props.$fixedBottom ? 'calc(24px + env(safe-area-inset-bottom))' : 'auto')};
   /* 고정 버튼은 뷰포트 가운데에, 최대 420px, 좌우 마진 16px 유지 */
   /* 프레임 기준 고정폭(343px), 더 좁은 뷰포트에선 100% - 32px로 안전 처리 */
-  width: ${props => props.fixedBottom ? 'min(343px, calc(100% - 32px))' : (props.fullWidth ? '100%' : 'auto')};
-  left: ${props => (props.fixedBottom ? '50%' : 'auto')};
-  transform: ${props => (props.fixedBottom ? 'translateX(-50%)' : 'none')};
+  width: ${props => props.$fixedBottom ? 'min(343px, calc(100% - 32px))' : (props.$fullWidth ? '100%' : 'auto')};
+  left: ${props => (props.$fixedBottom ? '50%' : 'auto')};
+  transform: ${props => (props.$fixedBottom ? 'translateX(-50%)' : 'none')};
 `
 
 function PrimaryButton({ children, onClick, fullWidth = true, fixedBottom = false, zIndex }) {
     return (
-        <Button onClick={onClick} fullWidth={fullWidth} fixedBottom={fixedBottom} zIndex={zIndex}>
+        <Button onClick={onClick} $fullWidth={fullWidth} $fixedBottom={fixedBottom} $zIndex={zIndex}>
             {children}
         </Button>
     )

--- a/src/components/taro/steps/QuestionStep.jsx
+++ b/src/components/taro/steps/QuestionStep.jsx
@@ -95,6 +95,14 @@ function QuestionStep({ next, prev, goTo }) {
       return nextAnswers
     })
 
+    // 세션에 누적 저장 (card_select input_text 용)
+    try {
+      const prevSaved = JSON.parse(sessionStorage.getItem('taro_answers') || '[]')
+      const nextSaved = [...prevSaved]
+      nextSaved[qIdx] = label
+      sessionStorage.setItem('taro_answers', JSON.stringify(nextSaved))
+    } catch {}
+
     // 첫 번째(디폴트) 질문 분기 처리
     if (qIdx === 0) {
       if (label === '아니야') {

--- a/src/components/taro/steps/QuestionStep.jsx
+++ b/src/components/taro/steps/QuestionStep.jsx
@@ -18,13 +18,39 @@ function QuestionStep({ next, prev, goTo }) {
   const [questions, setQuestions] = useState([])
   const [qIdx, setQIdx] = useState(0)
   const [answers, setAnswers] = useState([])
+  const [currentLocationLabel, setCurrentLocationLabel] = useState('현재 위치')
 
   const defaultFirstQuestion = {
-    question: "현재 방문하고 싶은 지역이 ‘현재 위치’가 맞아?",
+    question: `현재 방문하고 싶은 지역이 ‘${currentLocationLabel}’가 맞아?`,
     options: ["맞아", "아니야"],
   }
 
   useEffect(() => {
+    // 메인에서 설정한 위치명 우선
+    try {
+      const saved = JSON.parse(localStorage.getItem('selectedLocation') || '{}')
+      if (saved?.address) setCurrentLocationLabel(saved.address)
+    } catch {}
+
+    // 좌표만 있을 경우 역지오코딩으로 보정
+    try {
+      const raw = sessionStorage.getItem('user_selected_location')
+      if (raw) {
+        const pos = JSON.parse(raw)
+        const { kakao } = window
+        if (kakao?.maps?.services && typeof pos?.lat === 'number' && typeof pos?.lng === 'number') {
+          const geocoder = new kakao.maps.services.Geocoder()
+          geocoder.coord2RegionCode(pos.lng, pos.lat, (result, status) => {
+            if (status === kakao.maps.services.Status.OK) {
+              const region = result?.find(r => r.region_type === 'H') || result?.[0]
+              const label = region?.region_3depth_name || region?.region_2depth_name
+              if (label) setCurrentLocationLabel(label)
+            }
+          })
+        }
+      }
+    } catch {}
+
     let mounted = true
     ;(async () => {
       try {

--- a/src/components/taro/steps/ResultStep.jsx
+++ b/src/components/taro/steps/ResultStep.jsx
@@ -34,11 +34,13 @@ import retryCard from '../../../assets/icons/taro/RetryCard.svg'
 import detailCardBg from '../../../assets/icons/taro/ResultDetailCard.svg'
 import { savePlaceToServer } from '../../../apis/savePlaceApi'
 import { showToast } from '../../../hooks/common/toast'
+import { useSavedPlaceContext } from '../../../contexts/SavedPlaceContext'
 
 import { useNavigate } from 'react-router-dom'
 
 function ResultStep({ prev, goTo }) {
   const navigate = useNavigate()
+  const { addPlace, removePlace } = useSavedPlaceContext()
   const [cards, setCards] = useState(() => ([
     { id: 'I', title: '로딩 중', img: sampleImg, liked: false, desc: '' },
     { id: 'II', title: '로딩 중', img: sampleImg, liked: false, desc: '' },
@@ -149,9 +151,27 @@ function ResultStep({ prev, goTo }) {
                         setCards(prev => prev.map((card, i) => i === globalIndex ? { ...card, liked: !card.liked } : card))
                         return
                       }
+                      // 토글 동작: 이미 찜 상태면 해제, 아니면 저장
+                      if (target.liked) {
+                        try {
+                          removePlace(target.place_id)
+                          setCards(prev => prev.map((card, i) => i === globalIndex ? { ...card, liked: false } : card))
+                          showToast('찜을 해제했어요.')
+                        } catch {
+                          // 로컬 해제만 수행
+                          setCards(prev => prev.map((card, i) => i === globalIndex ? { ...card, liked: false } : card))
+                          showToast('찜을 해제했어요.')
+                        }
+                        return
+                      }
                       try {
-                        await savePlaceToServer(target.place_id)
-                        setCards(prev => prev.map((card, i) => i === globalIndex ? { ...card, liked: !card.liked } : card))
+                        const res = await savePlaceToServer(target.place_id)
+                        const placeData = res?.data ?? res
+                        if (placeData) {
+                          const toSave = { ...placeData, id: placeData.id || target.place_id }
+                          try { addPlace(toSave) } catch {}
+                        }
+                        setCards(prev => prev.map((card, i) => i === globalIndex ? { ...card, liked: true } : card))
                         showToast('장소가 저장되었습니다.')
                       } catch (e) {
                         showToast('저장 중 오류가 발생했어요.')

--- a/src/components/taro/steps/ResultStep.jsx
+++ b/src/components/taro/steps/ResultStep.jsx
@@ -66,7 +66,8 @@ function ResultStep({ prev, goTo }) {
   useEffect(() => {
     const applyFromStorage = (raw) => {
       try {
-        const select = JSON.parse(raw)
+        const parsed = JSON.parse(raw)
+        const select = Array.isArray(parsed) ? parsed : (parsed?.select || parsed?.data?.select || [])
         const shuffled = Array.isArray(select) ? [...select] : []
         for (let i = shuffled.length - 1; i > 0; i--) {
           const j = Math.floor(Math.random() * (i + 1))
@@ -77,10 +78,12 @@ function ResultStep({ prev, goTo }) {
         const mapped = picked.map((item, i) => ({
           id: ['I','II','III','IV','V','VI','VII'][i] || `${i+1}`,
           title: item.place_name || '추천 장소',
-          img: sampleImg,
+          img: (Array.isArray(item.place_photos) && item.place_photos.length > 0) ? item.place_photos[0] : sampleImg,
           liked: false,
-          desc: item.place_id || '',
+          desc: item.address || item.place_id || '',
           place_id: item.place_id,
+          address: item.address,
+          place_photos: item.place_photos,
         }))
         setCards(prev => {
           const stableRetry = prev.find(c => c.isRetry)

--- a/src/components/taro/steps/SpreadStep.jsx
+++ b/src/components/taro/steps/SpreadStep.jsx
@@ -28,6 +28,7 @@ function SpreadStep({ next, prev }) {
   const [translateX, setTranslateX] = useState(0)
   const [selectedCards, setSelectedCards] = useState([])
   const cardSpreadRef = useRef(null)
+  const hasRequestedRef = useRef(false)
 
   const totalCards = 25
   const cardsPerView = 25 //카드 퍼짐 넓이 조절
@@ -102,11 +103,15 @@ function SpreadStep({ next, prev }) {
 
       // 결과는 백그라운드로 요청하여 세션에 저장
       ;(async () => {
+        if (hasRequestedRef.current) return
+        hasRequestedRef.current = true
         try {
-          const result = await postCardSelect(selectedCards)
-          sessionStorage.setItem('taro_selected_result', JSON.stringify(result))
+          // 서버는 카드 인덱스 대신 위치/텍스트를 사용하므로 바로 호출
+          const result = await postCardSelect()
+          const payload = Array.isArray(result) ? { select: result } : result
+          sessionStorage.setItem('taro_selected_result', JSON.stringify(payload))
         } catch (e) {
-          sessionStorage.setItem('taro_selected_result', JSON.stringify([]))
+          sessionStorage.setItem('taro_selected_result', JSON.stringify({ select: [] }))
         }
       })()
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #63 

## Work Description 📝
- 타로 API 연결
- 현 위치 표시
- 타로 질문리스트 연결
- 카드 결과 api 연결 
- 찜 눌렀을 경우 PLAN 장바구니에 반영

## Screenshot 📸
<img width="372" height="806" alt="image" src="https://github.com/user-attachments/assets/5eee388e-7b95-4858-bea9-8f6b493f04af" />
<img width="378" height="813" alt="image" src="https://github.com/user-attachments/assets/27bce676-73a3-46c5-aa3f-43b1322280d8" />
<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/d9ee602a-4a65-4cea-886a-542f0c92d1af" />
<img width="377" height="807" alt="image" src="https://github.com/user-attachments/assets/d1cf5fee-778e-41c3-b2dd-d089eb394ae8" />



## To Reviewers 📢
전반적인 API 연결만 해서 나중에 다시 세세하게 확인해야하고 글자수에 따른 UI 수정도 필요함 ㅠ,ㅠ